### PR TITLE
Add Local LLM Support with Ollama

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,17 @@ htmlcov/
 
 # PDF/Report exports (optional - remove if you want to track them)
 *.pdf
+
+# DEPLOYMENT FILES (ignore for now)
+DEPLOYMENT.md
+
+# AWS deployment files (ignore for now)
+.aws/
+
+# GitHub Actions workflows (ignore for now)
+.github/
+
+# Docker files (ignore for now)
+Dockerfile
+Dockerfile.ollama
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ htmlcov/
 .env
 .env.local
 
-# PDF/Report exports (optional - remove if you want to track them)
+# PDF/Report exports
 *.pdf
 
 # DEPLOYMENT FILES (ignore for now)

--- a/README.md
+++ b/README.md
@@ -4,16 +4,69 @@ LLM Chat is a chatbot leveraging industry-standard LLM models (OpenAI, Gemini, A
 
 ## Installation
 
+### 1. Install Python Dependencies
+
 Use the package manager [pip](https://pip.pypa.io/en/stable/) to install necessary packages.
 
 ```bash
 pip install -r requirements.txt
 ```
 
-To start the program run the following command from the root of the project
+### 2. Configure API Keys
+
+Copy `.env.example` to `.env` and add your API keys:
+
+```bash
+# OpenAI API Key (optional)
+OPENAI_API_KEY=your_openai_key_here
+
+# Anthropic API Key (optional)
+ANTHROPIC_API_KEY=your_anthropic_key_here
+
+# Google API Key (optional)
+GOOGLE_API_KEY=your_google_api_key_here
+```
+
+### 3. (Optional) Setup Local LLM with Ollama
+
+For complete privacy and offline usage, you can run a local LLM:
+
+```bash
+# Run the setup script (macOS only)
+./setup_ollama.sh
+
+# Or install manually:
+brew install ollama
+ollama serve
+ollama pull llama3.2:1b
+```
+
+The local model will be available at `http://localhost:11434/v1/chat/completions`
+
+**Note**: Local models provide complete data privacy but with lower quality responses than cloud APIs. Perfect for development and privacy-sensitive applications.
+
+### 4. Start the Application
+
+To start the program run the following command from the root of the project:
 ```bash
 python manage.py
 ```
+
+The application will automatically detect and initialize available LLM providers (OpenAI, Anthropic, Google, and local Ollama).
+
+## Features
+
+### Conversation Context
+All conversations maintain context across messages, sending the **last 20 messages** to the LLM with each new message. This allows the AI to remember earlier parts of the conversation and provide contextually relevant responses.
+
+- System prompts are included at the beginning of each request
+- Older messages (beyond the last 20) are automatically dropped to manage token limits
+- To adjust the context window, modify the `limit(20)` value in `llm_chat/routes/conversations.py:260`
+
+### Performance Notes
+- **Cloud APIs** (OpenAI, Anthropic, Google): Fast responses (5-10 seconds)
+- **Local Ollama on M1 MacBook Air**: Slower responses (~30-60 seconds for Llama 3.2 1B)
+- Local models prioritize privacy over speed - ideal for development and sensitive data
 
 ## Documentation
 API documentation implemented with Swagger available at /docs

--- a/llm_chat/models/chat.py
+++ b/llm_chat/models/chat.py
@@ -34,10 +34,9 @@ class Model(db.Model):
         if not self.api_endpoint:
             return False
         try:
-            response = requests.get(
-                self.api_endpoint.replace('/v1/chat/completions', '/health'),
-                timeout=2
-            )
+            # Ollama uses /api/tags for health check
+            base_url = self.api_endpoint.replace('/v1/chat/completions', '')
+            response = requests.get(f"{base_url}/api/tags", timeout=2)
             return response.status_code == 200
         except Exception:
             return False

--- a/manage.py
+++ b/manage.py
@@ -71,7 +71,8 @@ def initialize_database():
                       config=json.dumps({'temperature': 0.7, 'max_tokens': 1000})),
                 Model(name='Gemini 1.5 Pro', provider='google', model_identifier='gemini-1.5-pro',
                       config=json.dumps({'temperature': 0.7, 'max_tokens': 1000})),
-                Model(name='Local Llama', provider='local', api_endpoint='http://localhost:8000/v1/chat/completions',
+                Model(name='Local Llama 3.2 1B', provider='local', api_endpoint='http://localhost:11434/v1/chat/completions',
+                      model_identifier='llama3.2:1b',
                       config=json.dumps({'temperature': 0.7, 'max_tokens': 2000})),
             ]
             for m in models:

--- a/setup_ollama.sh
+++ b/setup_ollama.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Setup script for Ollama local LLM
+
+set -e  # Exit on error
+
+echo "=== Ollama Setup Script ==="
+echo ""
+
+# Check if running on macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "This script is designed for macOS. For other platforms, see: https://ollama.ai"
+    exit 1
+fi
+
+# Check if Ollama is already installed
+if command -v ollama &> /dev/null; then
+    echo "✓ Ollama is already installed"
+    ollama --version
+else
+    echo "Installing Ollama..."
+    if command -v brew &> /dev/null; then
+        brew install ollama
+    else
+        echo "Homebrew not found. Please install from: https://ollama.ai"
+        exit 1
+    fi
+fi
+
+echo ""
+echo "=== Starting Ollama Service ==="
+# Check if Ollama is already running
+if pgrep -x "ollama" > /dev/null; then
+    echo "✓ Ollama service is already running"
+else
+    echo "Starting Ollama service in background..."
+    nohup ollama serve > /tmp/ollama.log 2>&1 &
+    sleep 2
+    echo "✓ Ollama service started"
+fi
+
+echo ""
+echo "=== Downloading Llama 3.2 1B Model ==="
+echo "This will download ~1GB of data..."
+ollama pull llama3.2:1b
+
+echo ""
+echo "=== Testing Ollama ==="
+# Test the endpoint
+if curl -s http://localhost:11434/api/tags > /dev/null; then
+    echo "✓ Ollama API is responding"
+    echo "Available models:"
+    curl -s http://localhost:11434/api/tags | python3 -m json.tool
+else
+    echo "✗ Ollama API is not responding. Please check the service."
+    exit 1
+fi
+
+echo ""
+echo "=== Setup Complete! ==="
+echo ""
+echo "Ollama is running at: http://localhost:11434"
+echo "Model endpoint: http://localhost:11434/v1/chat/completions"
+echo ""
+echo "To stop Ollama: killall ollama"
+echo "To restart Ollama: ollama serve"
+echo "To pull more models: ollama pull <model-name>"
+echo ""


### PR DESCRIPTION
### Summary
Implements local Llama model support via Ollama, providing a privacy-focused alternative to cloud-based LLM APIs for development and production deployments.

### Changes
  - Local Model Integration: Added Ollama support to LLM interface
  - Development Setup: Created setup_ollama.sh script for easy local installation (macOS)
  - Health Checks: Fixed local model availability checking to use Ollama's /api/tags endpoint