### PR TITLE
Fixes/go live

### DIFF
--- a/llm_chat/routes/provider.py
+++ b/llm_chat/routes/provider.py
@@ -3,7 +3,7 @@ from flask import Blueprint, render_template, jsonify, request, abort
 from flask_login import current_user
 from ..utils.decorators import role_required
 from ..extensions import db
-from ..models import User, Conversation, ProviderPatient, ProviderSettings
+from ..models import User, Conversation, ProviderPatient, ProviderSettings, ChatWindow
 
 provider_bp = Blueprint("provider", __name__, url_prefix="")
 
@@ -35,11 +35,17 @@ def get_provider_patients():
         conv = u.conversations.order_by(Conversation.updated_at.desc()).first()
         return conv.updated_at if conv else None
 
+    def visible_conversation_count(u: User):
+        return Conversation.query.join(ChatWindow).filter(
+            Conversation.user_id == u.id,
+            ChatWindow.visible == True
+        ).count()
+
     return jsonify([{
         'id': p.id,
         'username': p.username,
         'email': p.email,
-        'conversation_count': p.conversations.count(),
+        'conversation_count': visible_conversation_count(p),
         'last_active': last_active_for(p)
     } for p in patients])
 

--- a/llm_chat/routes/reports.py
+++ b/llm_chat/routes/reports.py
@@ -13,16 +13,24 @@ reports_bp = Blueprint("reports", __name__, url_prefix="/api/reports")
 @reports_bp.route("/", methods=["GET"])
 @login_required
 def get_reports():
-    """Get reports accessible to current user"""
+    """Get reports accessible to current user (only from visible windows)"""
     if current_user.is_patient():
-        # Patients see their own reports
-        reports = Report.query.filter_by(patient_id=current_user.id).order_by(Report.generated_at.desc()).all()
+        # Patients see their own reports from visible windows
+        reports = Report.query.join(ChatWindow).filter(
+            Report.patient_id == current_user.id,
+            ChatWindow.visible == True
+        ).order_by(Report.generated_at.desc()).all()
     elif current_user.is_provider():
-        # Providers see reports for their patients
-        reports = Report.query.filter_by(provider_id=current_user.id).order_by(Report.generated_at.desc()).all()
+        # Providers see reports for their patients from visible windows
+        reports = Report.query.join(ChatWindow).filter(
+            Report.provider_id == current_user.id,
+            ChatWindow.visible == True
+        ).order_by(Report.generated_at.desc()).all()
     elif current_user.is_admin():
-        # Admins see all reports
-        reports = Report.query.order_by(Report.generated_at.desc()).all()
+        # Admins see all reports from visible windows
+        reports = Report.query.join(ChatWindow).filter(
+            ChatWindow.visible == True
+        ).order_by(Report.generated_at.desc()).all()
     else:
         abort(403)
 
@@ -47,7 +55,7 @@ def get_report(report_id):
 @reports_bp.route("/patient/<int:patient_id>", methods=["GET"])
 @login_required
 def get_patient_reports(patient_id):
-    """Get all reports for a specific patient (provider only)"""
+    """Get all reports for a specific patient (provider only, visible windows only)"""
     if not current_user.is_provider() and not current_user.is_admin():
         abort(403)
 
@@ -55,7 +63,10 @@ def get_patient_reports(patient_id):
     if current_user.is_provider() and not current_user.can_access_patient(patient_id):
         abort(403)
 
-    reports = Report.query.filter_by(patient_id=patient_id).order_by(Report.generated_at.desc()).all()
+    reports = Report.query.join(ChatWindow).filter(
+        Report.patient_id == patient_id,
+        ChatWindow.visible == True
+    ).order_by(Report.generated_at.desc()).all()
     return jsonify([r.to_dict() for r in reports])
 
 

--- a/manage.py
+++ b/manage.py
@@ -62,15 +62,15 @@ def initialize_database():
         # Default models (only if none exist)
         if not Model.query.first():
             models = [
-                Model(name='GPT-4', provider='openai', model_identifier='gpt-4',
+                Model(name='GPT-4o', provider='openai', model_identifier='gpt-4o',
                       config=json.dumps({'temperature': 0.7, 'max_tokens': 1000})),
-                Model(name='GPT-3.5 Turbo', provider='openai', model_identifier='gpt-3.5-turbo',
+                Model(name='GPT-4o Mini', provider='openai', model_identifier='gpt-4o-mini',
                       config=json.dumps({'temperature': 0.7, 'max_tokens': 1000})),
-                Model(name='Claude 3 Opus', provider='anthropic', model_identifier='claude-3-opus-20240229',
+                Model(name='Claude Opus 4.5', provider='anthropic', model_identifier='claude-opus-4-5-20251101',
                       config=json.dumps({'temperature': 0.7, 'max_tokens': 1000})),
-                Model(name='Claude 3.5 Sonnet', provider='anthropic', model_identifier='claude-3-5-sonnet-20241022',
+                Model(name='Claude Sonnet 4.5', provider='anthropic', model_identifier='claude-sonnet-4-5-20250514',
                       config=json.dumps({'temperature': 0.7, 'max_tokens': 1000})),
-                Model(name='Gemini 1.5 Pro', provider='google', model_identifier='gemini-1.5-pro',
+                Model(name='Gemini 2.0 Flash', provider='google', model_identifier='gemini-2.0-flash',
                       config=json.dumps({'temperature': 0.7, 'max_tokens': 1000})),
                 Model(name='Llama 3.2 1B (Fast)', provider='local',
                       api_endpoint=f"{os.environ.get('OLLAMA_HOST', 'http://localhost:11434')}/v1/chat/completions",

--- a/templates/user_chat_windows.html
+++ b/templates/user_chat_windows.html
@@ -186,6 +186,26 @@
     </div>
   </aside>
 
+  <!-- Report Modal -->
+  <div id="reportModal" class="fixed inset-0 z-50 hidden">
+    <div class="absolute inset-0 bg-black/50" onclick="closeReportModal()"></div>
+    <div class="absolute inset-4 sm:inset-8 md:inset-12 lg:inset-16 flex flex-col rounded-2xl bg-white shadow-2xl overflow-hidden">
+      <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+        <h3 class="text-lg font-semibold text-slate-900">Session Report</h3>
+        <button onclick="closeReportModal()" class="rounded-md p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700">
+          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M6 6l12 12M6 18L18 6"/>
+          </svg>
+        </button>
+      </div>
+      <div id="reportModalContent" class="flex-1 overflow-y-auto p-6">
+        <div class="flex items-center justify-center h-32">
+          <p class="text-slate-500">Loading report...</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script>
     // Mobile sidebar toggle
     const menuBtn  = document.getElementById('menuBtn');
@@ -553,7 +573,7 @@
               `;
             }
 
-            // Template has a conversation - make it clickable
+            // Template has a conversation - make it clickable (read-only transcript view)
             return `
               <article class="flex h-full cursor-pointer flex-col justify-between rounded-xl border border-slate-200 bg-white p-5 text-left shadow-sm transition hover:border-indigo-300 hover:shadow"
                        onclick="window.location.href='/conversation/${conversationId}'">
@@ -565,7 +585,13 @@
                   <span class="inline-flex items-center rounded-full bg-indigo-50 px-2.5 py-0.5 text-xs font-semibold text-indigo-600">
                     ${escapeHtml(template.model || 'Model')}
                   </span>
-                  <span class="text-xs text-slate-500">View conversation</span>
+                  <button type="button"
+                          class="ml-auto inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:bg-slate-50">
+                    <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                    </svg>
+                    View Transcript
+                  </button>
                 </div>
               </article>
             `;
@@ -576,14 +602,14 @@
 
       // Add report button if report is ready
       const reportButton = status === 'report_ready'
-        ? `<a href="/my-reports?window_id=${window.id}"
+        ? `<button onclick="openReportModal(${window.id})"
                class="ml-2 inline-flex items-center gap-1.5 rounded-lg border border-purple-200 bg-purple-50 px-3 py-1.5 text-xs font-semibold text-purple-700 transition hover:bg-purple-100"
                title="View Report">
               <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
               </svg>
               View Report
-            </a>`
+            </button>`
         : '';
 
       return `
@@ -628,6 +654,37 @@
     async function logout() {
       await fetch('/logout');
       window.location.href = '/login';
+    }
+
+    async function openReportModal(windowId) {
+      const modal = document.getElementById('reportModal');
+      const content = document.getElementById('reportModalContent');
+
+      modal.classList.remove('hidden');
+      document.body.style.overflow = 'hidden';
+
+      content.innerHTML = `<div class="flex items-center justify-center h-32">
+        <p class="text-slate-500">Loading report...</p>
+      </div>`;
+
+      try {
+        const response = await fetch(`/api/reports/live/${windowId}`);
+        if (!response.ok) throw new Error('Failed to load report');
+
+        const data = await response.json();
+        content.innerHTML = data.html;
+      } catch (error) {
+        console.error('Error loading report:', error);
+        content.innerHTML = `<div class="flex items-center justify-center h-32">
+          <p class="text-red-600">Failed to load report. Please try again.</p>
+        </div>`;
+      }
+    }
+
+    function closeReportModal() {
+      const modal = document.getElementById('reportModal');
+      modal.classList.add('hidden');
+      document.body.style.overflow = '';
     }
 
     async function loadSelections() {


### PR DESCRIPTION
## Changes

### Visibility filtering
  - `provider.py`: Conversation counts now only include conversations from visible chat windows
  - `reports.py`: Report listings filter by visible windows for patients, providers, and admins

### Model updates
  - `manage.py`: Replace deprecated models with current versions:
    - GPT-4 → GPT-4o, GPT-3.5 Turbo → GPT-4o Mini
    - Claude 3 Opus → Claude Opus 4.5, Claude 3.5 Sonnet → Claude Sonnet 4.5
    - Gemini 1.5 Pro → Gemini 2.0 Flash

### User experience improvements
  - View Report button now opens the report directly in a modal instead of navigating to reports page
  - Chat cards in closed windows show "View Transcript" button instead of generic link