### PR TITLE
fix: Filter by visible windows on dashboards, add report modal

### DIFF
--- a/llm_chat/routes/conversations.py
+++ b/llm_chat/routes/conversations.py
@@ -172,16 +172,16 @@ def get_conversations():
         if c.window_id:
             window = ChatWindow.query.get(c.window_id)
             if window:
+                # Skip conversations in hidden windows
+                if not window.visible:
+                    continue
                 window_end_date = window.end_date
                 window_start_date = window.start_date
                 window_title = window.title
                 window_description = window.description
                 window_status = window.compute_status(now)
                 is_upcoming = window_status == 'scheduled'
-                if not window.visible:
-                    is_active = False
-                else:
-                    is_active = window_status == 'active'
+                is_active = window_status == 'active'
 
         if len(msgs) == 0 and not c.visible:
             continue
@@ -197,6 +197,7 @@ def get_conversations():
             'visible': c.visible,
             'is_active': is_active,
             'is_upcoming': is_upcoming,
+            'window_id': c.window_id,
             'window_status': window_status,
             'window_end_date': window_end_date,
             'window_start_date': window_start_date,

--- a/templates/provider_dashboard.html
+++ b/templates/provider_dashboard.html
@@ -181,8 +181,10 @@
     }
 
     function renderStats(patients, windows) {
-      const active   = windows.filter(w => w.is_current);
-      const templates= windows.reduce((s,w)=> s + (w.templates?.length || 0), 0);
+      // Only count visible windows
+      const visibleWindows = windows.filter(w => w.visible);
+      const active   = visibleWindows.filter(w => w.is_current);
+      const templates= visibleWindows.reduce((s,w)=> s + (w.templates?.length || 0), 0);
 
       const card = (label, value) => `
         <div class="rounded-xl bg-white p-5 shadow-sm ring-1 ring-slate-100">
@@ -192,7 +194,7 @@
 
       document.getElementById('statsGrid').innerHTML =
         card('Total Patients', patients.length) +
-        card('Chat Windows', windows.length) +
+        card('Chat Windows', visibleWindows.length) +
         card('Active Windows', active.length) +
         card('Chat Templates', templates);
     }

--- a/templates/user_dashboard.html
+++ b/templates/user_dashboard.html
@@ -196,6 +196,26 @@
     </div>
   </div>
 
+  <!-- Report Modal -->
+  <div id="reportModal" class="fixed inset-0 z-50 hidden">
+    <div class="absolute inset-0 bg-black/50" onclick="closeReportModal()"></div>
+    <div class="absolute inset-4 sm:inset-8 md:inset-12 lg:inset-16 flex flex-col rounded-2xl bg-white shadow-2xl overflow-hidden">
+      <div class="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+        <h3 class="text-lg font-semibold text-slate-900">Session Report</h3>
+        <button onclick="closeReportModal()" class="rounded-md p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700">
+          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M6 6l12 12M6 18L18 6"/>
+          </svg>
+        </button>
+      </div>
+      <div id="reportModalContent" class="flex-1 overflow-y-auto p-6">
+        <div class="flex items-center justify-center h-32">
+          <p class="text-slate-500">Loading report...</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Saved selections drawer -->
   <div id="selectionsOverlay" class="fixed inset-0 z-30 hidden bg-black/20"></div>
 
@@ -492,14 +512,14 @@
 
       // Add report button if report is ready
       const reportButton = statusKey === 'report_ready'
-        ? `<a href="/my-reports?window_id=${window.window_id}"
+        ? `<button onclick="event.stopPropagation(); openReportModal(${window.window_id})"
                class="inline-flex items-center gap-1.5 rounded-lg border border-purple-200 bg-purple-50 px-3 py-1.5 text-xs font-semibold text-purple-700 transition hover:bg-purple-100"
                title="View Report">
               <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
               </svg>
               View Report
-            </a>`
+            </button>`
         : '';
 
       const conversationsHtml = window.conversations
@@ -591,7 +611,7 @@
               status === 'generating_report'
                 ? `<span class="text-indigo-600">⏳ Generating...</span>`
                 : status === 'report_ready'
-                  ? `<a class="font-medium text-purple-600 hover:text-purple-700 underline" href="/my-reports">View Report</a>`
+                  ? `<button onclick="event.stopPropagation(); openReportModal(${conv.window_id})" class="font-medium text-purple-600 hover:text-purple-700 underline">View Report</button>`
                   : `<span class="text-slate-500">→</span>`
             }
           </div>
@@ -698,7 +718,7 @@
                 ? `<div class="mt-3 pt-3 border-t border-slate-100">
                      <span class="text-sm text-slate-600">
                        <span aria-hidden="true">📄</span>
-                       Report ready — view under <a class="font-medium text-purple-600 hover:text-purple-700 underline" href="/my-reports">My Reports</a>
+                       Report ready — <button onclick="event.stopPropagation(); openReportModal(${conv.window_id})" class="font-medium text-purple-600 hover:text-purple-700 underline">View Report</button>
                      </span>
                    </div>`
                 : ''
@@ -955,6 +975,37 @@
     async function logout() {
       await fetch('/logout');
       window.location.href = '/login';
+    }
+
+    async function openReportModal(windowId) {
+      const modal = document.getElementById('reportModal');
+      const content = document.getElementById('reportModalContent');
+
+      modal.classList.remove('hidden');
+      document.body.style.overflow = 'hidden';
+
+      content.innerHTML = `<div class="flex items-center justify-center h-32">
+        <p class="text-slate-500">Loading report...</p>
+      </div>`;
+
+      try {
+        const response = await fetch(`/api/reports/live/${windowId}`);
+        if (!response.ok) throw new Error('Failed to load report');
+
+        const data = await response.json();
+        content.innerHTML = data.html;
+      } catch (error) {
+        console.error('Error loading report:', error);
+        content.innerHTML = `<div class="flex items-center justify-center h-32">
+          <p class="text-red-600">Failed to load report. Please try again.</p>
+        </div>`;
+      }
+    }
+
+    function closeReportModal() {
+      const modal = document.getElementById('reportModal');
+      modal.classList.add('hidden');
+      document.body.style.overflow = '';
     }
 
     loadConversations();


### PR DESCRIPTION
## Changes
  - `conversations.py`: Skip conversations in hidden windows, add `window_id` to response
  - `provider_dashboard.html`: Stats only count visible windows
  - `user_dashboard.html`: Added report modal, View Report buttons open modal directly